### PR TITLE
fix(paths): Support archived_posts paths with .html suffix

### DIFF
--- a/src/pages/[year]/[month]/[slug].html.astro
+++ b/src/pages/[year]/[month]/[slug].html.astro
@@ -1,0 +1,23 @@
+---
+import { getCollection } from "astro:content";
+
+export async function getStaticPaths() {
+    const allPosts = await getCollection("archived_post");
+
+    return allPosts.map((post) => {
+        const slug = post.data.name
+        const postDate = post.data.time
+        const year = String(postDate.getFullYear())
+        const month = String(postDate.getMonth() + 1).padStart(2, '0');
+
+        return {
+            params: { month, year, slug }
+        }
+    });
+}
+
+const { year, month, slug } = Astro.params;
+
+// Redirect to the URL without .html suffix
+return Astro.redirect(`/${year}/${month}/${slug}`, 301);
+---


### PR DESCRIPTION
Some pages linked to my archived_posts with a .html suffix like /2012/02/iphone-developers-conference-advisory-board.html Those paths resulted in a 404, but now they work.

Closes #14