### PR TITLE
fix: Change favicon and add meta description

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,9 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Developer terminal icon">
+	<title>Developer terminal icon</title>
+	<g fill="none" stroke="url(#terminal-gradient)" stroke-linecap="round" stroke-linejoin="round">
+		<path stroke-width="16" d="m80 96 40 32-40 32m56 0h40" />
+		<rect
+			width="192"
+			height="160"
+			x="32"
+			y="48"
+			rx="8.5"
+			stroke-width="16.97"
+		/>
+	</g>
+	<defs>
+		<linearGradient id="terminal-gradient" x1="23" x2="235" y1="43" y2="202" gradientUnits="userSpaceOnUse">
+			<stop stop-color="#c561f6" />
+			<stop offset="0.5" stop-color="#7611a6" />
+			<stop offset="1" stop-color="#1c0056" />
+		</linearGradient>
+	</defs>
 </svg>

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -8,7 +8,7 @@ interface Props {
 
 const {
 	title = 'Johannes Fahrenkrug: Software Developer & Consultant',
-	description = '',
+	description = 'Berlin-based developer and consultant crafting iOS, full-stack, and AI solutions.',
 } = Astro.props;
 ---
 


### PR DESCRIPTION
Fav Icon is now a "cli prompt" instead of the generic Astro logo. Short meta desc.

Closes GH-28 and GH-31